### PR TITLE
Changes receive methods to handle split messages

### DIFF
--- a/src/WebSocketManager/WebSocketHandler.cs
+++ b/src/WebSocketManager/WebSocketHandler.cs
@@ -91,9 +91,8 @@ namespace WebSocketManager
             }
         }
 
-        public async Task ReceiveAsync(WebSocket socket, WebSocketReceiveResult result, byte[] buffer)
+        public async Task ReceiveAsync(WebSocket socket, WebSocketReceiveResult result, string serializedInvocationDescriptor)
         {
-            var serializedInvocationDescriptor = Encoding.UTF8.GetString(buffer, 0, result.Count);
             var invocationDescriptor = JsonConvert.DeserializeObject<InvocationDescriptor>(serializedInvocationDescriptor);
 
             var method = this.GetType().GetMethod(invocationDescriptor.MethodName);

--- a/src/WebSocketManager/WebSocketManagerMiddleware.cs
+++ b/src/WebSocketManager/WebSocketManagerMiddleware.cs
@@ -1,5 +1,7 @@
 using System;
+using System.IO;
 using System.Net.WebSockets;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -11,7 +13,7 @@ namespace WebSocketManager
         private readonly RequestDelegate _next;
         private WebSocketHandler _webSocketHandler { get; set; }
 
-        public WebSocketManagerMiddleware(RequestDelegate next, 
+        public WebSocketManagerMiddleware(RequestDelegate next,
                                           WebSocketHandler webSocketHandler)
         {
             _next = next;
@@ -20,50 +22,66 @@ namespace WebSocketManager
 
         public async Task Invoke(HttpContext context)
         {
-            if(!context.WebSockets.IsWebSocketRequest)
+            if (!context.WebSockets.IsWebSocketRequest)
                 return;
-            
+
             var socket = await context.WebSockets.AcceptWebSocketAsync();
             await _webSocketHandler.OnConnected(socket);
-            
-            await Receive(socket, async(result, buffer) =>
+
+            await Receive(socket, async (result, serializedInvocationDescriptor) =>
             {
-                if(result.MessageType == WebSocketMessageType.Text)
+                if (result.MessageType == WebSocketMessageType.Text)
                 {
-                    await _webSocketHandler.ReceiveAsync(socket, result, buffer);
+                    await _webSocketHandler.ReceiveAsync(socket, result, serializedInvocationDescriptor);
                     return;
                 }
 
-                else if(result.MessageType == WebSocketMessageType.Close)
+                else if (result.MessageType == WebSocketMessageType.Close)
                 {
                     try
                     {
                         await _webSocketHandler.OnDisconnected(socket);
                     }
 
-                    catch(WebSocketException e)
+                    catch (WebSocketException e)
                     {
+                        throw; //let's not swallow any exception for now
                     }
 
                     return;
                 }
 
             });
-            
+
             //TODO - investigate the Kestrel exception thrown when this is the last middleware
             //await _next.Invoke(context);
         }
 
-        private async Task Receive(WebSocket socket, Action<WebSocketReceiveResult, byte[]> handleMessage)
+        private async Task Receive(WebSocket socket, Action<WebSocketReceiveResult, string> handleMessage)
         {
-            var buffer = new byte[1024 * 4];
-
-            while(socket.State == WebSocketState.Open)
+            while (socket.State == WebSocketState.Open)
             {
-                var result = await socket.ReceiveAsync(buffer: new ArraySegment<byte>(buffer),
-                                                       cancellationToken: CancellationToken.None);
+                ArraySegment<Byte> buffer = new ArraySegment<byte>(new Byte[1024 * 4]);
+                string serializedInvocationDescriptor = null;
+                WebSocketReceiveResult result = null;
+                using (var ms = new MemoryStream())
+                {
+                    do
+                    {
+                        result = await socket.ReceiveAsync(buffer, CancellationToken.None);
+                        ms.Write(buffer.Array, buffer.Offset, result.Count);
+                    }
+                    while (!result.EndOfMessage);
 
-                handleMessage(result, buffer);                
+                    ms.Seek(0, SeekOrigin.Begin);
+
+                    using (var reader = new StreamReader(ms, Encoding.UTF8))
+                    {
+                        serializedInvocationDescriptor = await reader.ReadToEndAsync();
+                    }
+                }
+
+                handleMessage(result, serializedInvocationDescriptor);
             }
         }
     }


### PR DESCRIPTION
Sometimes a message can arrive in chunks (can be simulated by using
a smaller buffer size) so it's not safe to assume a single
webSocket.ReadAsync will return the whole message. This commit changes
all receive methods so they can handle messages in chunks by looping
until result.EndOfMessage is true.