### PR TITLE
Use location.host instead of hardcoded localhost value

### DIFF
--- a/samples/ChatApplication/wwwroot/client.html
+++ b/samples/ChatApplication/wwwroot/client.html
@@ -18,7 +18,7 @@
 
     <script language="javascript" type="text/javascript">
 
-            var connection = new WebSocketManager.Connection("ws://localhost:" + location.port + "/chat");
+            var connection = new WebSocketManager.Connection("ws://" + location.host + "/chat");
             connection.enableLogging = true;
 
             connection.connectionMethods.onConnected = () => {


### PR DESCRIPTION
Minor tweak to remove the hardcoded "localhost" value from the ChatApplication sample.