### PR TITLE
Fix issue with invoking next middleware.

### DIFF
--- a/src/WebSocketManager/WebSocketManagerMiddleware.cs
+++ b/src/WebSocketManager/WebSocketManagerMiddleware.cs
@@ -23,7 +23,10 @@ namespace WebSocketManager
         public async Task Invoke(HttpContext context)
         {
             if (!context.WebSockets.IsWebSocketRequest)
+            {
+                await _next.Invoke(context);
                 return;
+            }
 
             var socket = await context.WebSockets.AcceptWebSocketAsync().ConfigureAwait(false);
             await _webSocketHandler.OnConnected(socket).ConfigureAwait(false);
@@ -52,9 +55,6 @@ namespace WebSocketManager
                 }
 
             });
-
-            //TODO - investigate the Kestrel exception thrown when this is the last middleware
-            //await _next.Invoke(context);
         }
 
         private async Task Receive(WebSocket socket, Action<WebSocketReceiveResult, string> handleMessage)


### PR DESCRIPTION
If websocket is handled, we don't want any further middleware. Only non-websocket requests should be passed to next middleware.