### PR TITLE
Fixes sending websocket messages with international letters (UTF8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,5 @@ While it is still in development, you can see some examples of usage in the [`sa
 Contribute to **websocket-manager**
 -----------------------------------
 
-Contributions in any form are welcome! Submit issues with bugs and reccomandations! 
+Contributions in any form are welcome! Submit issues with bugs and recommendations! 
 **Pull Requests** are highly appreciated!

--- a/src/WebSocketManager/WebSocketHandler.cs
+++ b/src/WebSocketManager/WebSocketHandler.cs
@@ -111,7 +111,7 @@ namespace WebSocketManager
             {
                 method.Invoke(this, invocationDescriptor.Arguments);
             }
-            catch (TargetParameterCountException e)
+            catch (TargetParameterCountException)
             {
                 await SendMessageAsync(socket, new Message()
                 {
@@ -120,7 +120,7 @@ namespace WebSocketManager
                 }).ConfigureAwait(false);
             }
 
-            catch (ArgumentException e)
+            catch (ArgumentException)
             {
                 await SendMessageAsync(socket, new Message()
                 {

--- a/src/WebSocketManager/WebSocketHandler.cs
+++ b/src/WebSocketManager/WebSocketHandler.cs
@@ -44,9 +44,10 @@ namespace WebSocketManager
                 return;
 
             var serializedMessage = JsonConvert.SerializeObject(message, _jsonSerializerSettings);
-            await socket.SendAsync(buffer: new ArraySegment<byte>(array: Encoding.ASCII.GetBytes(serializedMessage),
+            var encodedMessage = Encoding.UTF8.GetBytes(serializedMessage);
+            await socket.SendAsync(buffer: new ArraySegment<byte>(array: encodedMessage,
                                                                   offset: 0,
-                                                                  count: serializedMessage.Length),
+                                                                  count: encodedMessage.Length),
                                    messageType: WebSocketMessageType.Text,
                                    endOfMessage: true,
                                    cancellationToken: CancellationToken.None).ConfigureAwait(false);


### PR DESCRIPTION
Hi! Thanks for the project.

We we're having some encoding issues. Now messages are sent (through SendMessageAsync) using ASCII. This leads to some letters (like æ, ø, å) not working (which is a big issue for us). Messages should be sent as UTF-8. This PR does that.

This PR also fixes an error selecting array segment buffer length, as that became apparent with converting to UTF-8. Now the serialized string length is used for buffer length, but strictly this should be the array segment length. Non-issue when using ASCII, but now when using UTF-8.

Let me know if there are any questions or if you need me to do any changes.