### PR TITLE
Update WebSocketManagerExtensions.cs

### DIFF
--- a/src/WebSocketManager/WebSocketManagerExtensions.cs
+++ b/src/WebSocketManager/WebSocketManagerExtensions.cs
@@ -7,11 +7,13 @@ namespace WebSocketManager
 {
     public static class WebSocketManagerExtensions
     {
-        public static IServiceCollection AddWebSocketManager(this IServiceCollection services)
+        public static IServiceCollection AddWebSocketManager(this IServiceCollection services, Assembly assembly = null)
         {
             services.AddTransient<WebSocketConnectionManager>();
+            
+            Assembly ass = assembly ?? Assembly.GetEntryAssembly();
 
-            foreach (var type in Assembly.GetEntryAssembly().ExportedTypes)
+            foreach (var type in ass.ExportedTypes)
             {
                 if (type.GetTypeInfo().BaseType == typeof(WebSocketHandler))
                 {


### PR DESCRIPTION
for the situation if my subclass inherits from WebSocketHandler does not exist in the entry assembly.
so I can setup in the startup.cs like this:
`services.AddWebSocketManager(Assembly.GetAssembly(typeof(NotifierHub)));`