### PR TITLE
Client no longer crashes when a method is called that doesn't exist.

### DIFF
--- a/src/WebSocketManager.Client/Connection.cs
+++ b/src/WebSocketManager.Client/Connection.cs
@@ -64,13 +64,12 @@ namespace WebSocketManager.Client
       await _clientWebSocket.SendAsync(new ArraySegment<byte>(bytes), WebSocketMessageType.Text, true, CancellationToken.None);
     }
     private void Invoke(InvocationDescriptor invocationDescriptor)
-        {
-			if (!_handlers.ContainsKey(invocationDescriptor.MethodName))
-                return;
-            var invocationHandler = _handlers[invocationDescriptor.MethodName];
-            if (invocationHandler != null)
-                invocationHandler.Handler(invocationDescriptor.Arguments);
-        }
+    {
+      if (_handlers.TryGetValue(invocationDescriptor.MethodName, out InvocationHandler invocationHandler))
+      {
+        invocationHandler.Handler(invocationDescriptor.Arguments);
+      }
+    }
 
         public async Task StopConnectionAsync()
         {

--- a/src/WebSocketManager.Client/Connection.cs
+++ b/src/WebSocketManager.Client/Connection.cs
@@ -65,6 +65,8 @@ namespace WebSocketManager.Client
     }
     private void Invoke(InvocationDescriptor invocationDescriptor)
         {
+			if (!_handlers.ContainsKey(invocationDescriptor.MethodName))
+                return;
             var invocationHandler = _handlers[invocationDescriptor.MethodName];
             if (invocationHandler != null)
                 invocationHandler.Handler(invocationDescriptor.Arguments);


### PR DESCRIPTION
The client has to register all methods with Connection.On, it will throw dictionary exceptions if the server sends an unexpected method and kill the connection. Now they will be simply ignored instead.

(This is identical to the server behavior of unknown commands)