### PR TITLE
Can now call StartConnectionAsync multiple times to restore connections.

### DIFF
--- a/src/WebSocketManager.Client/Connection.cs
+++ b/src/WebSocketManager.Client/Connection.cs
@@ -27,16 +27,15 @@ namespace WebSocketManager.Client
 
         public Connection()
         {
-            _clientWebSocket = new ClientWebSocket();
         }
 
         public async Task StartConnectionAsync(string uri)
         {
-            // the connection was lost, probably why we got called again.
-            if (_clientWebSocket.State != WebSocketState.Open)
+            // also check if connection was lost, that's probably why we get called multiple times.
+            if (_clientWebSocket == null || _clientWebSocket.State != WebSocketState.Open)
             {
                 // create a new web-socket so the next connect call works.
-                _clientWebSocket.Dispose();
+                _clientWebSocket?.Dispose();
                 _clientWebSocket = new ClientWebSocket();
             }
             // don't do anything, we are already connected.

--- a/src/WebSocketManager.Client/Connection.cs
+++ b/src/WebSocketManager.Client/Connection.cs
@@ -32,6 +32,16 @@ namespace WebSocketManager.Client
 
         public async Task StartConnectionAsync(string uri)
         {
+            // the connection was lost, probably why we got called again.
+            if (_clientWebSocket.State != WebSocketState.Open)
+            {
+                // create a new web-socket so the next connect call works.
+                _clientWebSocket.Dispose();
+                _clientWebSocket = new ClientWebSocket();
+            }
+            // don't do anything, we are already connected.
+            else return;
+
             await _clientWebSocket.ConnectAsync(new Uri(uri), CancellationToken.None).ConfigureAwait(false);
 
             await Receive(_clientWebSocket, (message) =>
@@ -113,7 +123,7 @@ namespace WebSocketManager.Client
                 }
             }
         }
-		
+
         public async Task SendAsync(string method) => await SendAsync(new InvocationDescriptor { MethodName = method, Arguments = new object[] { } });
 
         public async Task SendAsync<T1>(string method, T1 arg1) => await SendAsync(new InvocationDescriptor { MethodName = method, Arguments = new object[] { arg1 } });


### PR DESCRIPTION
That is, without it crashing. This will allow people to write a simple loop like this to keep connections alive forever whenever they drop:

```csharp
// infinite loop that attempts to re-establish the connection if it's ever lost.
Task.Run(async () =>
{
	while (true)
	{
		try
		{
			await Connection.StartConnectionAsync("ws://localhost:5000/chat");
		}
		catch
		{
			// ignore exception and establish another connection in a second.
			System.Threading.Thread.Sleep(1000);
		}
	}
});
```