### PR TITLE
Client Connection: Made Invoke virtual for custom behavior.

### DIFF
--- a/src/WebSocketManager.Client/Connection.cs
+++ b/src/WebSocketManager.Client/Connection.cs
@@ -65,7 +65,14 @@ namespace WebSocketManager.Client
             await _clientWebSocket.SendAsync(new ArraySegment<byte>(bytes), WebSocketMessageType.Text, true, CancellationToken.None);
         }
 
-        private void Invoke(InvocationDescriptor invocationDescriptor)
+        /// <summary>
+        /// Called when an invoke method call has been received. The default implementation calls
+        /// actions registered with the <see cref="On(string, Action{object[]})"/> method.
+        /// </summary>
+        /// <param name="invocationDescriptor">
+        /// The invocation descriptor containing the method name and parameters.
+        /// </param>
+        protected virtual void Invoke(InvocationDescriptor invocationDescriptor)
         {
             var invocationHandler = _handlers[invocationDescriptor.MethodName];
             if (invocationHandler != null)
@@ -113,7 +120,7 @@ namespace WebSocketManager.Client
                 }
             }
         }
-		
+
         public async Task SendAsync(string method) => await SendAsync(new InvocationDescriptor { MethodName = method, Arguments = new object[] { } });
 
         public async Task SendAsync<T1>(string method, T1 arg1) => await SendAsync(new InvocationDescriptor { MethodName = method, Arguments = new object[] { arg1 } });


### PR DESCRIPTION
Similar to #63.

This allows me to use the original library without having to hack logic into the source to for example prefix method calls and find the method in different classes compared to having thousands of awkward .On(...) actions with object arrays.

Additionally:
* Added a bit of documentation to the virtual method.
* This is completely backwards compatible.