### PR TITLE
Fix for exceptions thrown on an unexpected client disconnection.

### DIFF
--- a/src/WebsocketManager/ConnectionManager.cs
+++ b/src/WebsocketManager/ConnectionManager.cs
@@ -43,7 +43,10 @@ namespace WebSocketManager
 
         public Task RemoveSocket(string id)
         {
-            _sockets.TryRemove(id, out _);
+            if (_sockets.TryRemove(id, out var socket))
+            {
+                socket.Dispose();
+            }
 
             return Task.CompletedTask;
         }

--- a/src/WebsocketManager/ConnectionManager.cs
+++ b/src/WebsocketManager/ConnectionManager.cs
@@ -25,19 +25,27 @@ namespace WebSocketManager
         {
             return _sockets.FirstOrDefault(p => p.Value == socket).Key;
         }
+        
         public void AddSocket(WebSocket socket)
         {
             _sockets.TryAdd(CreateConnectionId(), socket);
         }
 
-        public async Task RemoveSocket(string id)
+        public async Task CloseAndRemoveSocket(string id)
         {
-            WebSocket socket;
-            _sockets.TryRemove(id, out socket);
+            if (_sockets.TryRemove(id, out var socket))
+            {
+                await socket.CloseOutputAsync(closeStatus: WebSocketCloseStatus.NormalClosure, 
+                    statusDescription: "Closed by the ConnectionManager", 
+                    cancellationToken: CancellationToken.None);
+            }
+        }
 
-            await socket.CloseAsync(closeStatus: WebSocketCloseStatus.NormalClosure, 
-                                    statusDescription: "Closed by the ConnectionManager", 
-                                    cancellationToken: CancellationToken.None);
+        public Task RemoveSocket(string id)
+        {
+            _sockets.TryRemove(id, out _);
+
+            return Task.CompletedTask;
         }
 
         private string CreateConnectionId()

--- a/src/WebsocketManager/Handler.cs
+++ b/src/WebsocketManager/Handler.cs
@@ -20,6 +20,11 @@ namespace WebSocketManager
             WebSocketConnectionManager.AddSocket(socket);
         }
 
+        public virtual async Task OnCloseConnection(WebSocket socket)
+        {
+            await WebSocketConnectionManager.CloseAndRemoveSocket(WebSocketConnectionManager.GetId(socket));
+        }
+
         public virtual async Task OnDisconnected(WebSocket socket)
         {
             await WebSocketConnectionManager.RemoveSocket(WebSocketConnectionManager.GetId(socket));

--- a/src/WebsocketManager/Middleware.cs
+++ b/src/WebsocketManager/Middleware.cs
@@ -35,7 +35,14 @@ namespace WebSocketManager
                         }
                         else if(result.MessageType == WebSocketMessageType.Close)
                         {
-                            await _webSocketHandler.OnCloseConnection(socket);
+                            if (result.CloseStatus.HasValue && result.CloseStatus == WebSocketCloseStatus.EndpointUnavailable)
+                            {
+                                await _webSocketHandler.OnDisconnected(socket);
+                            }
+                            else
+                            {
+                                await _webSocketHandler.OnCloseConnection(socket);
+                            }
                         }
                     });
                 }

--- a/src/WebsocketManager/Middleware.cs
+++ b/src/WebsocketManager/Middleware.cs
@@ -35,14 +35,7 @@ namespace WebSocketManager
                         }
                         else if(result.MessageType == WebSocketMessageType.Close)
                         {
-                            if (result.CloseStatus.HasValue && result.CloseStatus == WebSocketCloseStatus.EndpointUnavailable)
-                            {
-                                await _webSocketHandler.OnDisconnected(socket);
-                            }
-                            else
-                            {
-                                await _webSocketHandler.OnCloseConnection(socket);
-                            }
+                            await _webSocketHandler.OnCloseConnection(socket);
                         }
                     });
                 }


### PR DESCRIPTION
If a WebSocket client disconnects without initiating the close handshake, an exception is thrown since the socket will be in an invalid state, so `CloseOutputAsync()` shouldn't be called, since there won't be anything to receive this message.

Also, `CloseAsync()` expects a full close handshake, whereas a `CloseOutputAsync()` will simply initiate the close and not wait for any response from a client, so in this case `CloseOutputAsync` is the one to use.

The API has changed slightly for the `ConnectionManager`, since the socket must still be removed on a client disconnection that did not involve the close handshake.