### PR TITLE
Possible memory leaks fix

### DIFF
--- a/src/WebSocketManager/WebSocketManagerMiddleware.cs
+++ b/src/WebSocketManager/WebSocketManagerMiddleware.cs
@@ -102,6 +102,11 @@ namespace WebSocketManager
                         socket.Abort();
                     }
                 }
+                catch (Exception e)
+                {
+                    await _webSocketHandler.OnDisconnected(socket);
+                    throw;
+                }
             }
 
             await _webSocketHandler.OnDisconnected(socket);


### PR DESCRIPTION
If an uncaught execution occurs in the custom handler, then the ConcurrentDictionary <string, WebSocket> _sockets collection in the WebSocketConnectionManager class may not be cleared, leading to memory leaks